### PR TITLE
ensure_unit works with astropy.table.Column, etc.

### DIFF
--- a/gunagala/tests/test_utils.py
+++ b/gunagala/tests/test_utils.py
@@ -1,0 +1,35 @@
+import pytest
+import astropy.units as u
+from astropy.table import Column
+
+from gunagala import utils
+
+
+def test_ensure_unit_quantity():
+    q = (1.0, 42) * u.imperial.furlong
+    result = utils.ensure_unit(q, u.m)
+    assert (result == q.to(u.m)).all()
+
+
+def test_ensure_unit_floats():
+    f = (1.0, 42.0)
+    result = utils.ensure_unit(f, u.m)
+    assert (result == f * u.m).all()
+
+
+def test_ensure_unit_column():
+    c = Column(data=(1.0, 42), name='test', unit=u.imperial.furlong)
+    result = utils.ensure_unit(c, u.m)
+    assert (result == c.to(u.m)).all()
+
+
+def test_ensure_unit_bad_unit():
+    with pytest.raises(u.UnitConversionError):
+        q = (1.0, 42) * u.fortnight
+        result = utils.ensure_unit(q, u.m)
+
+
+def test_ensure_unit_non_numeric():
+    with pytest.raises(ValueError):
+        s = "fortytwo"
+        result = utils.ensure_unit(s, u.m)

--- a/gunagala/utils/__init__.py
+++ b/gunagala/utils/__init__.py
@@ -28,9 +28,16 @@ def ensure_unit(arg, unit):
     arg : astropy.units.Quantity
         `arg` as an `astropy.units.Quantity` with units of `unit`.
     """
-    if not isinstance(arg, u.Quantity):
+    try:
+        arg = arg.to(unit)
+    except u.UnitConversionError as err:
+        # arg is a Quantity or compatible class, but the units are incompatible.
+        raise err
+    except:
+        # Some other exception means arg isn't a Quantity or compatible. Try converting it.
         arg = arg * unit
-    return arg.to(unit)
+
+    return arg
 
 
 def get_table_data(data_table, data_dir, column_names, column_units):


### PR DESCRIPTION
Enables ensure_unit to work with unit conversion capable objects that are not Quantity (e.g. astropy.table.Column)