### PR TITLE
Quick fix for FWHM bug

### DIFF
--- a/gunagala/optical_filter.py
+++ b/gunagala/optical_filter.py
@@ -288,15 +288,15 @@ class Filter:
             red_half_max_a = (wave1 + wave2) / 2
             red_half_max_b = wave2 + (wave2 - wave1)
 
-        peak_results = minimize_scalar(lambda x: -self.transmission(x).value,
-                                       method='Bounded',
-                                       bounds=(blue_half_max_a.value, red_half_max_b.value))
+            peak_results = minimize_scalar(lambda x: -self.transmission(x).value,
+                                           method='Bounded',
+                                           bounds=(blue_half_max_a.value, red_half_max_b.value))
 
-        if not peak_results.success:
-            raise RuntimeError("Failed to find peak of filter transmission profile!")
+            if not peak_results.success:
+                raise RuntimeError("Failed to find peak of filter transmission profile!")
 
-        self._lambda_peak = peak_results.x * u.nm
-        self._peak = self.transmission(self._lambda_peak)
+            self._lambda_peak = peak_results.x * u.nm
+            self._peak = self.transmission(self._lambda_peak)
 
         blue_half_max_results = brentq(lambda x: self.transmission(x).value - self._peak.value  / 2,
                                        blue_half_max_a.value,

--- a/gunagala/tests/test_psf.py
+++ b/gunagala/tests/test_psf.py
@@ -67,7 +67,7 @@ def test_n_pix(psf):
 
 
 def test_n_pix_pix(pix_psf):
-    assert pix_psf.n_pix / u.pixel == pytest.approx(21.01351017)
+    assert pix_psf.n_pix.to(u.pixel).value == pytest.approx(21.01351017)
 
 
 def test_peak(psf):
@@ -75,7 +75,7 @@ def test_peak(psf):
 
 
 def test_peak_pix(pix_psf):
-    assert pix_psf.peak * u.pixel == pytest.approx(0.08073066)
+    assert pix_psf.peak.to(u.pixel).value == pytest.approx(0.08073066)
 
 
 def test_shape(psf):

--- a/gunagala/tests/test_psf.py
+++ b/gunagala/tests/test_psf.py
@@ -75,7 +75,7 @@ def test_peak(psf):
 
 
 def test_peak_pix(pix_psf):
-    assert pix_psf.peak.to(u.pixel).value == pytest.approx(0.08073066)
+    assert pix_psf.peak.to(1 / u.pixel).value == pytest.approx(0.08073066)
 
 
 def test_shape(psf):


### PR DESCRIPTION
This is a quick fix for a bug that can sometimes causes a tabulated data optical filter to fail to calculate its FWHM.

The cause of the problem was that the peak transmission value calculated by maximising the linearly interpolated transmission was slightly lower than the maximum transmission value in the tabulated data.  For tabulated data filters the latter was being used to find wavelengths that bracketed the half maximum points, but then the peak value was being recalculated using the former method, which sometimes resulted in the half maximum points being outside the brackets. This quick fix avoids the problem by not recalculating the peak transmission value for tabulated data filters, and simply uses the maximum value from the tabulated data instead.

A better fix would also stop using solvers to find the half maximum points for the tabulated filters too, as a simple linear interpolation would be more robust and efficient in their case.