### PR TITLE
Solved minor bugs in load_config.py and imager.py

### DIFF
--- a/gunagala/config.py
+++ b/gunagala/config.py
@@ -56,7 +56,7 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
     config_files = listify(config_files)
     config = dict()
 
-    config_dir = 'data'
+    config_dir = os.path.join(os.path.dirname(__file__), 'data')
 
     for f in config_files:
         if not f.endswith('.yaml'):

--- a/gunagala/config.py
+++ b/gunagala/config.py
@@ -54,7 +54,6 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
     if config_files is None:
         config_files = ['pocs']
     config_files = listify(config_files)
-
     config = dict()
 
     config_dir = 'data'
@@ -76,6 +75,9 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
         # Load local version of config
         if not ignore_local:
             local_version = os.path.join(config_dir, f.replace('.', '_local.'))
+            if not local_version.startswith('/'):
+                local_version = get_pkg_data_filename(local_version)
+
             if os.path.exists(local_version):
                 try:
                     _add_to_conf(config, local_version)

--- a/gunagala/imager.py
+++ b/gunagala/imager.py
@@ -72,7 +72,7 @@ def create_imagers(config=None):
 
             # Put in cache
             optics[optic_name] = optic
-            camera_name = imager_info['camera']
+        camera_name = imager_info['camera']
         try:
             # Try to get from cache
             camera = cameras[camera_name]


### PR DESCRIPTION
Hi Anthony,

These are two minor changes, which are: 

1. Adding and `if` statement to make `load_config.py` to find the `performance_local.yaml` in `data` directory where all the config files are located. 

2. Removal of an extra indentation from `imager.py` when building the dictionary with the cameras. This was causing to neglect the properties of any extra imager that the user might put into `performance_local.yaml` and just taking the ones from the first camera in the dictionary.

Hope this helps a bit to improve `gunagala`'s functionality.

Cheers,
Jaime.