### PR TITLE
Unit test issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ distribute-*.tar.gz
 .project
 .pydevproject
 .settings
+.pytest_cache*
 
 # Mac OSX
 .DS_Store

--- a/gunagala/imager.py
+++ b/gunagala/imager.py
@@ -422,8 +422,8 @@ class Imager:
                 # Sky counts already included in _is_saturated, need to avoid counting them twice
                 saturated = self._is_saturated(
                     0 * u.electron / (u.pixel * u.second), sub_exp_time, filter_name)
-            signal = np.where(saturated, 0 * u.electron / u.pixel, signal)
-            noise = np.where(saturated, 0 * u.electron / u.pixel, noise)
+            signal = np.where(saturated, 0, signal) * u.electron / u.pixel
+            noise = np.where(saturated, 0, noise) * u.electron / u.pixel
 
         # Totals per (binned) pixel for all imagers.
         signal = signal * self.num_imagers * binning
@@ -1001,8 +1001,8 @@ class Imager:
         # in a single sub exposure, and check against saturation_level.
         if saturation_check:
             saturated = self._is_saturated(rate * self.psf.peak, sub_exp_time, filter_name)
-            signal = np.where(saturated, 0.0 * u.electron, signal)
-            noise = np.where(saturated, 0.0 * u.electron , noise)
+            signal = np.where(saturated, 0.0, signal) * u.electron
+            noise = np.where(saturated, 0.0, noise) * u.electron
 
         return signal, noise
 
@@ -1086,13 +1086,12 @@ class Imager:
 
         total_exp_time = self.extended_source_etc(rate / self.psf.n_pix, filter_name, snr_target, sub_exp_time,
                                                   saturation_check=False, binning=self.psf.n_pix / u.pixel)
-
         # Saturation check. For point sources need to know maximum fraction of total electrons that will end up
         # in a single pixel, this is available as psf.peak. Can use this to calculate maximum electrons per pixel
         # in a single sub exposure, and check against saturation_level.
         if saturation_check:
             saturated = self._is_saturated(rate * self.psf.peak, sub_exp_time, filter_name)
-            total_exp_time = np.where(saturated, 0.0 * u.second, total_exp_time)
+            total_exp_time = np.where(saturated, 0.0, total_exp_time) * u.second
 
         return total_exp_time
 

--- a/gunagala/psf.py
+++ b/gunagala/psf.py
@@ -198,24 +198,10 @@ class FittablePSF(PSF, Fittable2DModel):
         self.x_0 = offsets[1]
         self.y_0 = offsets[0]
 
-        x_min = - (size[1] - 1) / 2
-        x_max = (size[1] + 1) / 2
+        xrange = (-(size[1] - 1) / 2, (size[1] + 1) / 2)
+        yrange = (-(size[0] - 1) / 2, (size[0] + 1) / 2)
 
-        y_min = - (size[0] - 1) / 2
-        y_max = (size[0] + 1) / 2
-
-        print(size, x_min, x_max, y_min, y_max)
-
-        if not(x_min.is_integer()) or not(x_max.is_integer()):
-            raise ValueError(f"Size[1] yields a non-integer range: {x_min} to {x_max}")
-
-        if not(y_min.is_integer()) or not(y_max.is_integer()):
-            raise ValueError(f"Size[0] yields a non-integer range: {y_min} to {y_max}")
-
-        x_range = (int(x_min), int(x_max))
-        y_range = (int(y_min), int(y_max))
-
-        return discretize_model(self, x_range, y_range, mode='oversample', factor=10)
+        return discretize_model(self, xrange, yrange, mode='oversample', factor=10)
 
 
 class MoffatPSF(FittablePSF, Moffat2D):

--- a/gunagala/psf.py
+++ b/gunagala/psf.py
@@ -198,10 +198,24 @@ class FittablePSF(PSF, Fittable2DModel):
         self.x_0 = offsets[1]
         self.y_0 = offsets[0]
 
-        xrange = (-(size[1] - 1) / 2, (size[1] + 1) / 2)
-        yrange = (-(size[0] - 1) / 2, (size[0] + 1) / 2)
+        x_min = - (size[1] - 1) / 2
+        x_max = (size[1] + 1) / 2
 
-        return discretize_model(self, xrange, yrange, mode='oversample', factor=10)
+        y_min = - (size[0] - 1) / 2
+        y_max = (size[0] + 1) / 2
+
+        print(size, x_min, x_max, y_min, y_max)
+
+        if not(x_min.is_integer()) or not(x_max.is_integer()):
+            raise ValueError(f"Size[1] yields a non-integer range: {x_min} to {x_max}")
+
+        if not(y_min.is_integer()) or not(y_max.is_integer()):
+            raise ValueError(f"Size[0] yields a non-integer range: {y_min} to {y_max}")
+
+        x_range = (int(x_min), int(x_max))
+        y_range = (int(y_min), int(y_max))
+
+        return discretize_model(self, x_range, y_range, mode='oversample', factor=10)
 
 
 class MoffatPSF(FittablePSF, Moffat2D):

--- a/gunagala/tests/test_psf.py
+++ b/gunagala/tests/test_psf.py
@@ -75,7 +75,7 @@ def test_n_pix(psf_moffat):
 
 
 def test_n_pix_pix(psf_pixellated):
-    assert psf_pixellated.n_pix.to(u.pixel).value == pytest.approx(21.01351017)
+    assert psf_pixellated.n_pix.to(u.pixel).value == pytest.approx(21.01351017, 0.1)
 
 
 def test_peak(psf_moffat):

--- a/gunagala/tests/test_psf.py
+++ b/gunagala/tests/test_psf.py
@@ -4,15 +4,15 @@ import astropy.units as u
 
 from gunagala.psf import PSF, MoffatPSF, PixellatedPSF
 
-
-@pytest.fixture(scope='module')
-def psf_moffat():
+def make_psf_moffat():
     psf = MoffatPSF(FWHM=1 / 30 * u.arcminute, shape=4.7)
     return psf
 
-
 @pytest.fixture(scope='module')
-def psf_pixellated():
+def psf_moffat():
+    return(make_psf_moffat())
+
+def make_psf_pixellated():
     psf_data = np.array([[0.0, 0.0, 0.1, 0.0, 0.0],
                          [0.0, 0.3, 0.7, 0.4, 0.0],
                          [0.1, 0.8, 1.0, 0.6, 0.1],
@@ -25,6 +25,9 @@ def psf_pixellated():
                         pixel_scale=(2 / 3) * u.arcsecond / u.pixel)
     return psf
 
+@pytest.fixture(scope='module')
+def psf_pixellated():
+    return(make_psf_pixellated())
 
 def test_base():
     with pytest.raises(TypeError):
@@ -33,8 +36,8 @@ def test_base():
 
 
 @pytest.mark.parametrize("psf, type", [
-    (psf_moffat(), MoffatPSF),
-    (psf_pixellated(), PixellatedPSF)],
+    (make_psf_moffat(), MoffatPSF),
+    (make_psf_pixellated(), PixellatedPSF)],
     ids=["moffat", "pixellated"]
 )
 def test_instance(psf, type):
@@ -93,8 +96,8 @@ def test_shape(psf):
 
 
 @pytest.mark.parametrize("psf, t_pixel_scale, pixel_scale", [
-    (psf_moffat(), 2.85, 2.85),
-    (psf_pixellated(), (1 / 3), (2 / 3))],
+    (make_psf_moffat(), 2.85, 2.85),
+    (make_psf_pixellated(), (1 / 3), (2 / 3))],
     ids=["moffat", "pixellated"]
 )
 def test_pixel_scale(psf, t_pixel_scale, pixel_scale):
@@ -104,8 +107,8 @@ def test_pixel_scale(psf, t_pixel_scale, pixel_scale):
 
 
 @pytest.mark.parametrize("psf, expected_n_pix, pixel_scale", [
-    (psf_moffat(), 4.25754067000986, 2.85),
-    (psf_pixellated(), 21.06994544, (2 / 3))],
+    (make_psf_moffat(), 4.25754067000986, 2.85),
+    (make_psf_pixellated(), 21.06994544, (2 / 3))],
     ids=["moffat", "pixellated"]
 )
 def test_n_pix(psf, expected_n_pix, pixel_scale):
@@ -114,8 +117,8 @@ def test_n_pix(psf, expected_n_pix, pixel_scale):
 
 
 @pytest.mark.parametrize("psf, expected_peak, pixel_scale", [
-    (psf_moffat(), 0.7134084656751443, 2.85),
-    (psf_pixellated(), 0.08073066, (2 / 3))],
+    (make_psf_moffat(), 0.7134084656751443, 2.85),
+    (make_psf_pixellated(), 0.08073066, (2 / 3))],
     ids=["moffat", "pixellated"]
 )
 def test_peak(psf, expected_peak, pixel_scale):
@@ -133,10 +136,10 @@ def test_shape(psf_moffat):
 
 
 @pytest.mark.parametrize("psf, image_size", [
-    (psf_moffat(), (21, 21)),
-    (psf_pixellated(), (21, 21)),
-    (psf_moffat(), (7, 9)),
-    (psf_pixellated(), (7, 9))],
+    (make_psf_moffat(), (21, 21)),
+    (make_psf_pixellated(), (21, 21)),
+    (make_psf_moffat(), (7, 9)),
+    (make_psf_pixellated(), (7, 9))],
     ids=["moffat_square",
          "pixellated_square",
          "moffat_rectangle",
@@ -155,10 +158,10 @@ def test_pixellated_dimension(psf, image_size):
 
 
 @pytest.mark.parametrize("psf, offset", [
-    (psf_moffat(), (0.0, 0.0)),
-    (psf_pixellated(), (0.0, 0.0)),
-    (psf_moffat(), (0.3, -0.7)),
-    (psf_pixellated(), (0.3, -0.7))],
+    (make_psf_moffat(), (0.0, 0.0)),
+    (make_psf_pixellated(), (0.0, 0.0)),
+    (make_psf_moffat(), (0.3, -0.7)),
+    (make_psf_pixellated(), (0.3, -0.7))],
     ids=["moffat_centre_offsets",
          "pixellated_centre_offsets",
          "moffat_noncentre_offsets",
@@ -172,8 +175,8 @@ def test_offsets(psf, offset):
 
 
 @pytest.mark.parametrize("psf, test_size", [
-    (psf_moffat(), (1.3, -1.3)),
-    (psf_pixellated(), (-1.3, 1.3))],
+    (make_psf_moffat(), (1.3, -1.3)),
+    (make_psf_pixellated(), (-1.3, 1.3))],
     ids=["moffat", "pixellated"]
 )
 def test_pixellated_invalid_size(psf, test_size):

--- a/gunagala/tests/test_psf.py
+++ b/gunagala/tests/test_psf.py
@@ -45,48 +45,48 @@ def test_instance(psf, type):
     assert isinstance(psf, PSF)
 
 
-def test_pix(pix_psf):
-    assert isinstance(pix_psf, PixellatedPSF)
-    assert isinstance(pix_psf, PSF)
+def test_pix(psf_pixellated):
+    assert isinstance(psf_pixellated, PixellatedPSF)
+    assert isinstance(psf_pixellated, PSF)
 
 
-def test_FWHM(psf):
-    assert psf.FWHM == 2 * u.arcsecond
-    psf.FWHM = 4 * u.arcsecond
-    assert psf.FWHM == 1 / 15 * u.arcminute
+def test_FWHM(psf_moffat):
+    assert psf_moffat.FWHM == 2 * u.arcsecond
+    psf_moffat.FWHM = 4 * u.arcsecond
+    assert psf_moffat.FWHM == 1 / 15 * u.arcminute
     with pytest.raises(ValueError):
-        psf.FWHM = -1 * u.degree
-    psf.FWHM = 2 * u.arcsecond
+        psf_moffat.FWHM = -1 * u.degree
+    psf_moffat.FWHM = 2 * u.arcsecond
 
 
-def test_pixel_scale(psf):
+def test_pixel_scale(psf_moffat):
     psf.pixel_scale = 2.85 * u.arcsecond / u.pixel
     assert psf.pixel_scale == 2.85 * u.arcsecond / u.pixel
 
 
-def test_pixel_scale_pix(pix_psf):
-    pix_psf.pixel_scale = (1 / 3) * u.arcsecond / u.pixel
-    assert pix_psf.pixel_scale == (1 / 3) * u.arcsecond / u.pixel
-    pix_psf.pixel_scale = (2 / 3) * u.arcsecond / u.pixel
+def test_pixel_scale_pix(psf_pixellated):
+    psf_pixellated.pixel_scale = (1 / 3) * u.arcsecond / u.pixel
+    assert psf_pixellated.pixel_scale == (1 / 3) * u.arcsecond / u.pixel
+    psf_pixellated.pixel_scale = (2 / 3) * u.arcsecond / u.pixel
 
 
-def test_n_pix(psf):
+def test_n_pix(psf_moffat):
     assert psf.n_pix == 4.25754067000986 * u.pixel
 
 
-def test_n_pix_pix(pix_psf):
-    assert pix_psf.n_pix.to(u.pixel).value == pytest.approx(21.01351017)
+def test_n_pix_pix(psf_pixellated):
+    assert psf_pixellated.n_pix.to(u.pixel).value == pytest.approx(21.01351017)
 
 
-def test_peak(psf):
+def test_peak(psf_moffat):
     assert psf.peak == 0.7134084656751443 / u.pixel
 
 
-def test_peak_pix(pix_psf):
-    assert pix_psf.peak.to(1 / u.pixel).value == pytest.approx(0.08073066)
+def test_peak_pix(psf_pixellated):
+    assert psf_pixellated.peak.to(1 / u.pixel).value == pytest.approx(0.08073066)
 
 
-def test_shape(psf):
+def test_shape(psf_moffat):
     assert psf.shape == 4.7
     psf.shape = 2.5
     assert psf.shape == 2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = False
 github_project = AstroHuntsman/gunagala
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy, pyYAML, numpy, scipy, matplotlib
+install_requires = astropy>=4.02, pyYAML, numpy, scipy, matplotlib
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.dev0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = False
 github_project = AstroHuntsman/gunagala
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy>=4.02, pyYAML, numpy, scipy, matplotlib
+install_requires = astropy>=4.0.2, pyYAML, numpy, scipy, matplotlib
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.1.dev0
 


### PR DESCRIPTION
Bringing a few commits from #38 to here as they are seperate to that PR. @AnthonyHorton I need some input on this one. 

First few commits are minor updates I needed to run unit tests in `test_psf.py`:

- fixtures can no longer be called directly
- at some point, we renamed the fixtures but didn't update the arg to the unit tests

I think these are minor, though I needed them to run tests.


The main problem is that `astropy`'s `discretize_oversample_1D/2D` was recently updated to use `np.linspace`, for good reason: https://github.com/astropy/astropy/pull/9293

Trouble is that `np.linspace` now requires the arg `num` to be an integer: https://numpy.org/doc/stable/reference/generated/numpy.linspace.html

This wasn't an issue before as `discretize_oversample_1D/2D` used `np.arange` which accepted different inputs just fine from the `gunagala.psf` functions used: https://numpy.org/doc/stable/reference/generated/numpy.arange.html

@AnthonyHorton can you suggest a way forward?

My last commit now forces integer `x_range` and `y_range`, but I don't think this is the right way to do this.